### PR TITLE
feat: retry with backoff, batch operations, attachment downloads

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { registerActionsTools } from './tools/actions.js';
 
 // Import types
 import { TrelloCredentials } from './types/common.js';
+import { fetchWithRetry } from './utils/api.js';
 
 // Load environment variables
 dotenv.config();
@@ -32,7 +33,7 @@ const credentials: TrelloCredentials = {
 
 // Define resources (same as before)
 server.resource('boards', 'trello://boards', async (uri) => {
-	const response = await fetch(
+	const response = await fetchWithRetry(
 		`https://api.trello.com/1/members/me/boards?key=${trelloApiKey}&token=${trelloApiToken}`
 	);
 	const data = await response.json();
@@ -50,7 +51,7 @@ server.resource(
 	'lists',
 	new ResourceTemplate('trello://boards/{boardId}/lists', { list: undefined }),
 	async (uri, { boardId }) => {
-		const response = await fetch(
+		const response = await fetchWithRetry(
 			`https://api.trello.com/1/boards/${boardId}/lists?key=${trelloApiKey}&token=${trelloApiToken}`
 		);
 		const data = await response.json();
@@ -69,7 +70,7 @@ server.resource(
 	'cards',
 	new ResourceTemplate('trello://lists/{listId}/cards', { list: undefined }),
 	async (uri, { listId }) => {
-		const response = await fetch(
+		const response = await fetchWithRetry(
 			`https://api.trello.com/1/lists/${listId}/cards?key=${trelloApiKey}&token=${trelloApiToken}`
 		);
 		const data = await response.json();

--- a/src/tools/actions.ts
+++ b/src/tools/actions.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { TrelloCredentials } from '../types/common.js';
+import { fetchWithRetry } from '../utils/api.js';
 
 /**
  * Register all Actions API tools
@@ -45,7 +46,7 @@ export function registerActionsTools(server: McpServer, credentials: TrelloCrede
 				if (memberCreatorFields) url.searchParams.append('memberCreator_fields', memberCreatorFields);
 				if (memberFields) url.searchParams.append('member_fields', memberFields);
 
-				const response = await fetch(url.toString());
+				const response = await fetchWithRetry(url.toString());
 				const data = await response.json();
 
 				return {
@@ -91,7 +92,7 @@ export function registerActionsTools(server: McpServer, credentials: TrelloCrede
 					};
 				}
 
-				const response = await fetch(
+				const response = await fetchWithRetry(
 					`https://api.trello.com/1/actions/${actionId}?key=${credentials.apiKey}&token=${credentials.apiToken}`,
 					{
 						method: 'PUT',
@@ -147,7 +148,7 @@ export function registerActionsTools(server: McpServer, credentials: TrelloCrede
 					};
 				}
 
-				const response = await fetch(
+				const response = await fetchWithRetry(
 					`https://api.trello.com/1/actions/${actionId}?key=${credentials.apiKey}&token=${credentials.apiToken}`,
 					{
 						method: 'DELETE',
@@ -208,7 +209,7 @@ export function registerActionsTools(server: McpServer, credentials: TrelloCrede
 				if (member !== undefined) url.searchParams.append('member', member.toString());
 				if (emoji !== undefined) url.searchParams.append('emoji', emoji.toString());
 
-				const response = await fetch(url.toString());
+				const response = await fetchWithRetry(url.toString());
 				const data = await response.json();
 
 				return {

--- a/src/tools/boards.ts
+++ b/src/tools/boards.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { TrelloCredentials } from '../types/common.js';
+import { fetchWithRetry } from '../utils/api.js';
 
 /**
  * Register all Boards API tools
@@ -39,7 +40,7 @@ export function registerBoardsTools(server: McpServer, credentials: TrelloCreden
 					queryParams.append('organization', 'true');
 				}
 
-				const response = await fetch(
+				const response = await fetchWithRetry(
 					`https://api.trello.com/1/members/me/boards?${queryParams}`
 				);
 				const data = await response.json();

--- a/src/tools/cards.ts
+++ b/src/tools/cards.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { TrelloCredentials } from '../types/common.js';
+import { fetchWithRetry } from '../utils/api.js';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 
 /**
  * Register all Cards API tools
@@ -589,4 +592,190 @@ export function registerCardsTools(server: McpServer, credentials: TrelloCredent
 			}
 		}
 	);
-} 
+
+	// GET /cards/{id}/attachments - List card attachments
+	server.tool(
+		'get-card-attachments',
+		{
+			cardId: z.string().describe('ID of the card to get attachments from'),
+		},
+		async ({ cardId }) => {
+			try {
+				if (!credentials.apiKey || !credentials.apiToken) {
+					return { content: [{ type: 'text' as const, text: 'Trello API credentials are not configured' }], isError: true };
+				}
+
+				const url = new URL(`https://api.trello.com/1/cards/${cardId}/attachments`);
+				url.searchParams.append('key', credentials.apiKey);
+				url.searchParams.append('token', credentials.apiToken);
+
+				const response = await fetchWithRetry(url.toString());
+				const attachments = await response.json();
+
+				// Also fetch comments to map attachments to comments
+				const actionsUrl = new URL(`https://api.trello.com/1/cards/${cardId}/actions`);
+				actionsUrl.searchParams.append('key', credentials.apiKey);
+				actionsUrl.searchParams.append('token', credentials.apiToken);
+				actionsUrl.searchParams.append('filter', 'commentCard');
+
+				const actionsResponse = await fetchWithRetry(actionsUrl.toString());
+				const comments = await actionsResponse.json();
+
+				// Map attachment URLs mentioned in comments
+				const attachmentCommentMap: Record<string, string> = {};
+				for (const comment of comments) {
+					const text: string = comment.data?.text || '';
+					for (const att of attachments) {
+						if (text.includes(att.name) || text.includes(att.id)) {
+							attachmentCommentMap[att.id] = text;
+						}
+					}
+				}
+
+				const summary = attachments.map((att: any) => ({
+					id: att.id,
+					name: att.name,
+					mimeType: att.mimeType,
+					bytes: att.bytes,
+					date: att.date,
+					isUpload: att.isUpload,
+					url: att.url,
+					commentContext: attachmentCommentMap[att.id] || null,
+				}));
+
+				return { content: [{ type: 'text' as const, text: JSON.stringify(summary, null, 2) }] };
+			} catch (error) {
+				return { content: [{ type: 'text' as const, text: `Error getting attachments: ${error}` }], isError: true };
+			}
+		}
+	);
+
+	// Download all image attachments from a card to a local folder
+	server.tool(
+		'download-card-attachments',
+		{
+			cardId: z.string().describe('ID of the card to download attachments from'),
+			savePath: z.string().describe('Local directory path to save attachments to'),
+			imagesOnly: z.boolean().optional().describe('Only download image files (default: true)'),
+		},
+		async ({ cardId, savePath, imagesOnly = true }) => {
+			try {
+				if (!credentials.apiKey || !credentials.apiToken) {
+					return { content: [{ type: 'text' as const, text: 'Trello API credentials are not configured' }], isError: true };
+				}
+
+				// Fetch card info
+				const cardUrl = new URL(`https://api.trello.com/1/cards/${cardId}`);
+				cardUrl.searchParams.append('key', credentials.apiKey);
+				cardUrl.searchParams.append('token', credentials.apiToken);
+				cardUrl.searchParams.append('fields', 'name,desc,shortUrl');
+				const cardResponse = await fetchWithRetry(cardUrl.toString());
+				const card = await cardResponse.json();
+
+				// Fetch attachments
+				const attUrl = new URL(`https://api.trello.com/1/cards/${cardId}/attachments`);
+				attUrl.searchParams.append('key', credentials.apiKey);
+				attUrl.searchParams.append('token', credentials.apiToken);
+				const attResponse = await fetchWithRetry(attUrl.toString());
+				const attachments = await attResponse.json();
+
+				// Fetch comments for context
+				const actionsUrl = new URL(`https://api.trello.com/1/cards/${cardId}/actions`);
+				actionsUrl.searchParams.append('key', credentials.apiKey);
+				actionsUrl.searchParams.append('token', credentials.apiToken);
+				actionsUrl.searchParams.append('filter', 'commentCard');
+				const actionsResponse = await fetchWithRetry(actionsUrl.toString());
+				const comments = await actionsResponse.json();
+
+				// Filter to images if needed
+				const IMAGE_MIMES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/svg+xml', 'image/bmp'];
+				const filtered = imagesOnly
+					? attachments.filter((a: any) => a.mimeType && IMAGE_MIMES.includes(a.mimeType))
+					: attachments;
+
+				if (filtered.length === 0) {
+					return { content: [{ type: 'text' as const, text: `No ${imagesOnly ? 'image ' : ''}attachments found on card "${card.name}"` }] };
+				}
+
+				// Ensure output directory
+				await fs.mkdir(savePath, { recursive: true });
+
+				// Download each attachment
+				const manifest: Array<{
+					file: string;
+					originalName: string;
+					mimeType: string;
+					bytes: number;
+					date: string;
+					commentContext: string | null;
+				}> = [];
+
+				// OAuth header for Trello file downloads (query params return 401)
+				const authHeader = `OAuth oauth_consumer_key="${credentials.apiKey}", oauth_token="${credentials.apiToken}"`;
+
+				for (let i = 0; i < filtered.length; i++) {
+					const att = filtered[i];
+
+					const fileResponse = await fetchWithRetry(att.url, {
+						headers: { 'Authorization': authHeader },
+					});
+					const buffer = Buffer.from(await fileResponse.arrayBuffer());
+
+					// Sanitize filename: {index}-{original_name}
+					const baseName = att.name.replace(/[^a-zA-Z0-9а-яА-ЯёЁ._-]/g, '_');
+					const fileName = `${String(i + 1).padStart(2, '0')}-${baseName}`;
+					const filePath = path.join(savePath, fileName);
+
+					await fs.writeFile(filePath, buffer);
+
+					// Find comment context
+					let commentContext: string | null = null;
+					for (const comment of comments) {
+						const text: string = comment.data?.text || '';
+						if (text.includes(att.name) || text.includes(att.id)) {
+							commentContext = text;
+							break;
+						}
+					}
+
+					manifest.push({
+						file: fileName,
+						originalName: att.name,
+						mimeType: att.mimeType,
+						bytes: buffer.length,
+						date: att.date,
+						commentContext,
+					});
+				}
+
+				// Write manifest
+				const manifestData = {
+					card: { id: cardId, name: card.name, description: card.desc, url: card.shortUrl },
+					downloadedAt: new Date().toISOString(),
+					files: manifest,
+				};
+				await fs.writeFile(
+					path.join(savePath, '_manifest.json'),
+					JSON.stringify(manifestData, null, 2),
+					'utf-8'
+				);
+
+				return {
+					content: [{
+						type: 'text' as const,
+						text: JSON.stringify({
+							savedTo: savePath,
+							card: card.name,
+							filesDownloaded: manifest.length,
+							files: manifest.map(m => ({ file: m.file, mimeType: m.mimeType, bytes: m.bytes, commentContext: m.commentContext })),
+						}, null, 2),
+					}],
+				};
+			} catch (error) {
+				return { content: [{ type: 'text' as const, text: `Error downloading attachments: ${error}` }], isError: true };
+			}
+		}
+	);
+}
+
+ 

--- a/src/tools/cards.ts
+++ b/src/tools/cards.ts
@@ -20,7 +20,7 @@ export function registerCardsTools(server: McpServer, credentials: TrelloCredent
 		},
 		async ({ name, description, listId }) => {
 			try {
-				const response = await fetch(
+				const response = await fetchWithRetry(
 					`https://api.trello.com/1/cards?key=${credentials.apiKey}&token=${credentials.apiToken}`,
 					{
 						method: 'POST',
@@ -74,7 +74,7 @@ export function registerCardsTools(server: McpServer, credentials: TrelloCredent
 			try {
 				const results = await Promise.all(
 					cards.map(async (card) => {
-						const response = await fetch(
+						const response = await fetchWithRetry(
 							`https://api.trello.com/1/cards?key=${credentials.apiKey}&token=${credentials.apiToken}`,
 							{
 								method: 'POST',
@@ -152,7 +152,7 @@ export function registerCardsTools(server: McpServer, credentials: TrelloCredent
 					};
 				}
 
-				const response = await fetch(
+				const response = await fetchWithRetry(
 					`https://api.trello.com/1/cards/${cardId}?key=${credentials.apiKey}&token=${credentials.apiToken}`,
 					{
 						method: 'PUT',
@@ -207,7 +207,7 @@ export function registerCardsTools(server: McpServer, credentials: TrelloCredent
 					};
 				}
 
-				const response = await fetch(
+				const response = await fetchWithRetry(
 					`https://api.trello.com/1/cards/${cardId}?key=${credentials.apiKey}&token=${credentials.apiToken}`,
 					{
 						method: 'PUT',
@@ -271,7 +271,7 @@ export function registerCardsTools(server: McpServer, credentials: TrelloCredent
 
 				const results = await Promise.all(
 					cards.map(async (card) => {
-						const response = await fetch(
+						const response = await fetchWithRetry(
 							`https://api.trello.com/1/cards/${card.cardId}?key=${credentials.apiKey}&token=${credentials.apiToken}`,
 							{
 								method: 'PUT',
@@ -330,7 +330,7 @@ export function registerCardsTools(server: McpServer, credentials: TrelloCredent
 					};
 				}
 
-				const response = await fetch(
+				const response = await fetchWithRetry(
 					`https://api.trello.com/1/cards/${cardId}/actions/comments?key=${credentials.apiKey}&token=${credentials.apiToken}`,
 					{
 						method: 'POST',
@@ -392,7 +392,7 @@ export function registerCardsTools(server: McpServer, credentials: TrelloCredent
 
 				const results = await Promise.all(
 					comments.map(async (comment) => {
-						const response = await fetch(
+						const response = await fetchWithRetry(
 							`https://api.trello.com/1/cards/${comment.cardId}/actions/comments?key=${credentials.apiKey}&token=${credentials.apiToken}`,
 							{
 								method: 'POST',
@@ -455,7 +455,7 @@ export function registerCardsTools(server: McpServer, credentials: TrelloCredent
 				url.searchParams.append('token', credentials.apiToken);
 				if (limit) url.searchParams.append('limit', limit.toString());
 
-				const response = await fetch(url.toString());
+				const response = await fetchWithRetry(url.toString());
 				const data = await response.json();
 				return {
 					content: [
@@ -499,7 +499,7 @@ export function registerCardsTools(server: McpServer, credentials: TrelloCredent
 					};
 				}
 
-				const response = await fetch(
+				const response = await fetchWithRetry(
 					`https://api.trello.com/1/cards/${cardId}?key=${credentials.apiKey}&token=${credentials.apiToken}`,
 					{
 						method: 'PUT',
@@ -556,7 +556,7 @@ export function registerCardsTools(server: McpServer, credentials: TrelloCredent
 
 				const results = await Promise.all(
 					cardIds.map(async (cardId) => {
-						const response = await fetch(
+						const response = await fetchWithRetry(
 							`https://api.trello.com/1/cards/${cardId}?key=${credentials.apiKey}&token=${credentials.apiToken}`,
 							{
 								method: 'PUT',

--- a/src/tools/labels.ts
+++ b/src/tools/labels.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { TrelloCredentials, TrelloColorEnum, TrelloColorWithNullEnum } from '../types/common.js';
+import { fetchWithRetry } from '../utils/api.js';
 
 /**
  * Register all Labels API tools
@@ -17,7 +18,7 @@ export function registerLabelsTools(server: McpServer, credentials: TrelloCreden
 		},
 		async ({ boardId, name, color }) => {
 			try {
-				const response = await fetch(
+				const response = await fetchWithRetry(
 					`https://api.trello.com/1/labels?key=${credentials.apiKey}&token=${credentials.apiToken}`,
 					{
 						method: 'POST',
@@ -63,7 +64,7 @@ export function registerLabelsTools(server: McpServer, credentials: TrelloCreden
 		},
 		async ({ cardId, labelId }) => {
 			try {
-				const response = await fetch(
+				const response = await fetchWithRetry(
 					`https://api.trello.com/1/cards/${cardId}/idLabels?key=${credentials.apiKey}&token=${credentials.apiToken}`,
 					{
 						method: 'POST',
@@ -114,7 +115,7 @@ export function registerLabelsTools(server: McpServer, credentials: TrelloCreden
 			try {
 				const results = await Promise.all(
 					labels.map(async (label) => {
-						const response = await fetch(
+						const response = await fetchWithRetry(
 							`https://api.trello.com/1/labels?key=${credentials.apiKey}&token=${credentials.apiToken}`,
 							{
 								method: 'POST',
@@ -167,7 +168,7 @@ export function registerLabelsTools(server: McpServer, credentials: TrelloCreden
 			try {
 				const results = await Promise.all(
 					items.map(async (item) => {
-						const response = await fetch(
+						const response = await fetchWithRetry(
 							`https://api.trello.com/1/cards/${item.cardId}/idLabels?key=${credentials.apiKey}&token=${credentials.apiToken}`,
 							{
 								method: 'POST',
@@ -230,7 +231,7 @@ export function registerLabelsTools(server: McpServer, credentials: TrelloCreden
 				url.searchParams.append('token', credentials.apiToken);
 				if (fields) url.searchParams.append('fields', fields);
 
-				const response = await fetch(url.toString());
+				const response = await fetchWithRetry(url.toString());
 				const data = await response.json();
 
 				return {
@@ -281,7 +282,7 @@ export function registerLabelsTools(server: McpServer, credentials: TrelloCreden
 				if (name !== undefined) updateData.name = name;
 				if (color !== undefined) updateData.color = color === 'null' ? null : color;
 
-				const response = await fetch(
+				const response = await fetchWithRetry(
 					`https://api.trello.com/1/labels/${labelId}?key=${credentials.apiKey}&token=${credentials.apiToken}`,
 					{
 						method: 'PUT',
@@ -335,7 +336,7 @@ export function registerLabelsTools(server: McpServer, credentials: TrelloCreden
 					};
 				}
 
-				const response = await fetch(
+				const response = await fetchWithRetry(
 					`https://api.trello.com/1/labels/${labelId}?key=${credentials.apiKey}&token=${credentials.apiToken}`,
 					{
 						method: 'DELETE',
@@ -395,7 +396,7 @@ export function registerLabelsTools(server: McpServer, credentials: TrelloCreden
 				url.searchParams.append('token', credentials.apiToken);
 				url.searchParams.append('value', value);
 
-				const response = await fetch(url.toString(), {
+				const response = await fetchWithRetry(url.toString(), {
 					method: 'PUT',
 					headers: {
 						'Content-Type': 'application/json',

--- a/src/tools/lists.ts
+++ b/src/tools/lists.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { TrelloCredentials } from '../types/common.js';
+import { fetchWithRetry } from '../utils/api.js';
 
 /**
  * Register all Lists API tools
@@ -15,7 +16,7 @@ export function registerListsTools(server: McpServer, credentials: TrelloCredent
 		},
 		async ({ boardId }) => {
 			try {
-				const response = await fetch(
+				const response = await fetchWithRetry(
 					`https://api.trello.com/1/boards/${boardId}/lists?key=${credentials.apiKey}&token=${credentials.apiToken}`
 				);
 				const data = await response.json();
@@ -63,7 +64,7 @@ export function registerListsTools(server: McpServer, credentials: TrelloCredent
 					};
 				}
 
-				const response = await fetch(
+				const response = await fetchWithRetry(
 					`https://api.trello.com/1/lists?key=${credentials.apiKey}&token=${credentials.apiToken}`,
 					{
 						method: 'POST',
@@ -130,7 +131,7 @@ export function registerListsTools(server: McpServer, credentials: TrelloCredent
 				if (pos !== undefined) updateData.pos = pos;
 				if (subscribed !== undefined) updateData.subscribed = subscribed;
 
-				const response = await fetch(
+				const response = await fetchWithRetry(
 					`https://api.trello.com/1/lists/${listId}?key=${credentials.apiKey}&token=${credentials.apiToken}`,
 					{
 						method: 'PUT',
@@ -184,7 +185,7 @@ export function registerListsTools(server: McpServer, credentials: TrelloCredent
 					};
 				}
 
-				const response = await fetch(
+				const response = await fetchWithRetry(
 					`https://api.trello.com/1/lists/${listId}/closed?key=${credentials.apiKey}&token=${credentials.apiToken}`,
 					{
 						method: 'PUT',
@@ -240,7 +241,7 @@ export function registerListsTools(server: McpServer, credentials: TrelloCredent
 					};
 				}
 
-				const response = await fetch(
+				const response = await fetchWithRetry(
 					`https://api.trello.com/1/lists/${listId}/idBoard?key=${credentials.apiKey}&token=${credentials.apiToken}`,
 					{
 						method: 'PUT',
@@ -301,7 +302,7 @@ export function registerListsTools(server: McpServer, credentials: TrelloCredent
 				url.searchParams.append('token', credentials.apiToken);
 				if (filter) url.searchParams.append('filter', filter);
 
-				const response = await fetch(url.toString());
+				const response = await fetchWithRetry(url.toString());
 				const data = await response.json();
 				return {
 					content: [
@@ -351,7 +352,7 @@ export function registerListsTools(server: McpServer, credentials: TrelloCredent
 				url.searchParams.append('token', credentials.apiToken);
 				if (fields) url.searchParams.append('fields', fields);
 
-				const response = await fetch(url.toString());
+				const response = await fetchWithRetry(url.toString());
 				const data = await response.json();
 				return {
 					content: [
@@ -403,7 +404,7 @@ export function registerListsTools(server: McpServer, credentials: TrelloCredent
 				if (fields) url.searchParams.append('fields', fields);
 				if (filter) url.searchParams.append('filter', filter);
 
-				const response = await fetch(url.toString());
+				const response = await fetchWithRetry(url.toString());
 				const data = await response.json();
 				return {
 					content: [
@@ -447,7 +448,7 @@ export function registerListsTools(server: McpServer, credentials: TrelloCredent
 					};
 				}
 
-				const response = await fetch(
+				const response = await fetchWithRetry(
 					`https://api.trello.com/1/lists/${listId}/archiveAllCards?key=${credentials.apiKey}&token=${credentials.apiToken}`,
 					{
 						method: 'POST',
@@ -501,7 +502,7 @@ export function registerListsTools(server: McpServer, credentials: TrelloCredent
 					};
 				}
 
-				const response = await fetch(
+				const response = await fetchWithRetry(
 					`https://api.trello.com/1/lists/${listId}/moveAllCards?key=${credentials.apiKey}&token=${credentials.apiToken}`,
 					{
 						method: 'POST',

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -5,13 +5,102 @@ import https from 'node:https';
 const keepAliveAgent = new https.Agent({
 	keepAlive: true,
 	keepAliveMsecs: 60_000,
-	maxSockets: 2,
+	maxSockets: 4,
 	timeout: 60_000,
 });
 
-const MAX_RETRIES = 5;
-const BASE_DELAY_MS = 1000;
+const MAX_RETRIES = 7;
+const BASE_DELAY_MS = 1500;
 const FETCH_TIMEOUT_MS = 60_000;
+
+// Trello limits: 100 req / 10 sec per token, 300 req / 10 sec per key
+// We target 80 req / 10 sec to stay safely under the token limit
+const WINDOW_MS = 10_000;
+const MAX_REQUESTS_PER_WINDOW = 80;
+const MIN_REQUEST_INTERVAL_MS = 120; // ~8 req/sec max serial throughput
+
+// ── Sliding Window Rate Limiter ──────────────────────────────────────
+// Tracks timestamps of all requests in the last WINDOW_MS
+const requestTimestamps: number[] = [];
+let requestCount = 0;
+
+function pruneWindow(): void {
+	const cutoff = Date.now() - WINDOW_MS;
+	while (requestTimestamps.length > 0 && requestTimestamps[0] <= cutoff) {
+		requestTimestamps.shift();
+	}
+}
+
+function getWindowUsage(): { count: number; oldestAge: number } {
+	pruneWindow();
+	const oldest = requestTimestamps.length > 0 ? Date.now() - requestTimestamps[0] : WINDOW_MS;
+	return { count: requestTimestamps.length, oldestAge: oldest };
+}
+
+// ── Mutex for serializing access to the rate limiter ─────────────────
+// Prevents race conditions when multiple tool calls fire concurrently
+let mutexQueue: Array<() => void> = [];
+let mutexLocked = false;
+
+async function acquireMutex(): Promise<void> {
+	if (!mutexLocked) {
+		mutexLocked = true;
+		return;
+	}
+	return new Promise(resolve => {
+		mutexQueue.push(() => {
+			mutexLocked = true;
+			resolve();
+		});
+	});
+}
+
+function releaseMutex(): void {
+	if (mutexQueue.length > 0) {
+		const next = mutexQueue.shift()!;
+		next();
+	} else {
+		mutexLocked = false;
+	}
+}
+
+// ── Throttle with sliding window + mutex ─────────────────────────────
+async function throttle(): Promise<void> {
+	await acquireMutex();
+	try {
+		// Enforce minimum interval between requests
+		const now = Date.now();
+		const lastTs = requestTimestamps.length > 0
+			? requestTimestamps[requestTimestamps.length - 1]
+			: 0;
+		const elapsed = now - lastTs;
+		if (elapsed < MIN_REQUEST_INTERVAL_MS) {
+			await new Promise(resolve => setTimeout(resolve, MIN_REQUEST_INTERVAL_MS - elapsed));
+		}
+
+		// Enforce sliding window limit
+		const { count } = getWindowUsage();
+		if (count >= MAX_REQUESTS_PER_WINDOW) {
+			// Wait until the oldest request falls out of the window
+			const waitMs = WINDOW_MS - (Date.now() - requestTimestamps[0]) + 50; // +50ms safety margin
+			console.error(`[TRELLO_MCP] Rate limit: ${count}/${MAX_REQUESTS_PER_WINDOW} in window, waiting ${waitMs}ms`);
+			await new Promise(resolve => setTimeout(resolve, Math.max(waitMs, 100)));
+			pruneWindow();
+		}
+
+		requestTimestamps.push(Date.now());
+		requestCount++;
+	} finally {
+		releaseMutex();
+	}
+}
+
+// ── Jitter helper ────────────────────────────────────────────────────
+function jitter(baseMs: number): number {
+	// Add ±25% random jitter to prevent thundering herd
+	const factor = 0.75 + Math.random() * 0.5;
+	return Math.round(baseMs * factor);
+}
 
 /**
  * Fetch wrapper using keep-alive https agent for Trello API URLs.
@@ -62,10 +151,18 @@ function keepAliveFetch(url: string, options?: RequestInit): Promise<Response> {
 }
 
 /**
- * Fetch with keep-alive + timeout + exponential backoff retry.
+ * Fetch with keep-alive + timeout + sliding window rate limit + exponential backoff retry with jitter.
  * Retries on network errors, 429 rate limits, and 5xx server errors.
  */
 export async function fetchWithRetry(url: string, options?: RequestInit): Promise<Response> {
+	await throttle();
+
+	const endpoint = url.replace(/https:\/\/api\.trello\.com\/1/, '').replace(/\?.*/, '');
+	const method = options?.method || 'GET';
+	const reqNum = requestCount;
+	const { count } = getWindowUsage();
+	console.error(`[TRELLO_MCP] #${reqNum} ${method} ${endpoint} [window: ${count}/${MAX_REQUESTS_PER_WINDOW}]`);
+
 	let lastError: Error | undefined;
 	for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
 		try {
@@ -80,15 +177,30 @@ export async function fetchWithRetry(url: string, options?: RequestInit): Promis
 			// Retry on 429 and 5xx
 			if ((response.status === 429 || response.status >= 500) && attempt < MAX_RETRIES - 1) {
 				const retryAfter = response.headers.get('Retry-After');
-				const delay = retryAfter ? parseInt(retryAfter, 10) * 1000 : BASE_DELAY_MS * Math.pow(2, attempt);
+				let delay: number;
+				if (retryAfter) {
+					delay = parseInt(retryAfter, 10) * 1000;
+				} else if (response.status === 429) {
+					// On 429, use longer backoff since we've hit the limit
+					delay = jitter(BASE_DELAY_MS * Math.pow(2, attempt + 1));
+				} else {
+					delay = jitter(BASE_DELAY_MS * Math.pow(2, attempt));
+				}
+				console.error(`[TRELLO_MCP] #${reqNum} → ${response.status}, retry in ${delay}ms (attempt ${attempt + 1}/${MAX_RETRIES})`);
 				await new Promise(resolve => setTimeout(resolve, delay));
+				// Re-throttle before retry to respect the window
+				await throttle();
 				continue;
 			}
+			console.error(`[TRELLO_MCP] #${reqNum} → ${response.status}`);
 			return response;
 		} catch (error) {
 			lastError = error as Error;
+			const delay = jitter(BASE_DELAY_MS * Math.pow(2, attempt));
+			console.error(`[TRELLO_MCP] #${reqNum} → ERROR: ${(error as Error).message}, retry in ${delay}ms (attempt ${attempt + 1}/${MAX_RETRIES})`);
 			if (attempt < MAX_RETRIES - 1) {
-				await new Promise(resolve => setTimeout(resolve, BASE_DELAY_MS * Math.pow(2, attempt)));
+				await new Promise(resolve => setTimeout(resolve, delay));
+				await throttle();
 			}
 		}
 	}
@@ -138,7 +250,7 @@ export function createTrelloUrl(endpoint: string, credentials: TrelloCredentials
 	const url = new URL(`https://api.trello.com/1${endpoint}`);
 	url.searchParams.append('key', credentials.apiKey);
 	url.searchParams.append('token', credentials.apiToken);
-	
+
 	if (params) {
 		Object.entries(params).forEach(([key, value]) => {
 			if (value !== undefined && value !== null) {
@@ -146,7 +258,7 @@ export function createTrelloUrl(endpoint: string, credentials: TrelloCredentials
 			}
 		});
 	}
-	
+
 	return url.toString();
 }
 
@@ -241,4 +353,4 @@ export async function trelloDelete(endpoint: string, credentials: TrelloCredenti
 	} catch (error) {
 		return createErrorResponse(`Error making DELETE request to ${endpoint}: ${error}`);
 	}
-} 
+}

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,4 +1,99 @@
 import { TrelloApiResponse, TrelloCredentials } from '../types/common.js';
+import https from 'node:https';
+
+// Persistent keep-alive agent — reuses TLS connections to avoid CloudFront blocking
+const keepAliveAgent = new https.Agent({
+	keepAlive: true,
+	keepAliveMsecs: 60_000,
+	maxSockets: 2,
+	timeout: 60_000,
+});
+
+const MAX_RETRIES = 5;
+const BASE_DELAY_MS = 1000;
+const FETCH_TIMEOUT_MS = 60_000;
+
+/**
+ * Fetch wrapper using keep-alive https agent for Trello API URLs.
+ * Falls back to regular fetch for non-Trello URLs.
+ */
+function keepAliveFetch(url: string, options?: RequestInit): Promise<Response> {
+	// Use keep-alive agent for Trello requests
+	if (url.includes('trello.com')) {
+		return new Promise((resolve, reject) => {
+			const parsedUrl = new URL(url);
+			const reqOptions: https.RequestOptions = {
+				hostname: parsedUrl.hostname,
+				path: parsedUrl.pathname + parsedUrl.search,
+				method: options?.method || 'GET',
+				agent: keepAliveAgent,
+				headers: {
+					...(options?.headers as Record<string, string> || {}),
+				},
+				signal: options?.signal as AbortSignal | undefined,
+			};
+
+			const req = https.request(reqOptions, (res) => {
+				const chunks: Buffer[] = [];
+				res.on('data', (chunk: Buffer) => chunks.push(chunk));
+				res.on('end', () => {
+					const body = Buffer.concat(chunks);
+					resolve(new Response(body, {
+						status: res.statusCode || 200,
+						statusText: res.statusMessage || '',
+						headers: new Headers(res.headers as Record<string, string>),
+					}));
+				});
+			});
+
+			req.on('error', reject);
+			req.on('timeout', () => {
+				req.destroy();
+				reject(new Error('Request timeout'));
+			});
+
+			if (options?.body) {
+				req.write(options.body);
+			}
+			req.end();
+		});
+	}
+	return fetch(url, options);
+}
+
+/**
+ * Fetch with keep-alive + timeout + exponential backoff retry.
+ * Retries on network errors, 429 rate limits, and 5xx server errors.
+ */
+export async function fetchWithRetry(url: string, options?: RequestInit): Promise<Response> {
+	let lastError: Error | undefined;
+	for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+		try {
+			const controller = new AbortController();
+			const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+			const response = await keepAliveFetch(url, {
+				...options,
+				signal: controller.signal,
+			});
+			clearTimeout(timeout);
+
+			// Retry on 429 and 5xx
+			if ((response.status === 429 || response.status >= 500) && attempt < MAX_RETRIES - 1) {
+				const retryAfter = response.headers.get('Retry-After');
+				const delay = retryAfter ? parseInt(retryAfter, 10) * 1000 : BASE_DELAY_MS * Math.pow(2, attempt);
+				await new Promise(resolve => setTimeout(resolve, delay));
+				continue;
+			}
+			return response;
+		} catch (error) {
+			lastError = error as Error;
+			if (attempt < MAX_RETRIES - 1) {
+				await new Promise(resolve => setTimeout(resolve, BASE_DELAY_MS * Math.pow(2, attempt)));
+			}
+		}
+	}
+	throw lastError;
+}
 
 /**
  * Create a success response for Trello API
@@ -65,7 +160,7 @@ export async function trelloGet(endpoint: string, credentials: TrelloCredentials
 		}
 
 		const url = createTrelloUrl(endpoint, credentials, params);
-		const response = await fetch(url);
+		const response = await fetchWithRetry(url);
 		const data = await response.json();
 
 		return createSuccessResponse(data);
@@ -84,7 +179,7 @@ export async function trelloPost(endpoint: string, credentials: TrelloCredential
 		}
 
 		const url = createTrelloUrl(endpoint, credentials, params);
-		const response = await fetch(url, {
+		const response = await fetchWithRetry(url, {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
@@ -109,7 +204,7 @@ export async function trelloPut(endpoint: string, credentials: TrelloCredentials
 		}
 
 		const url = createTrelloUrl(endpoint, credentials, params);
-		const response = await fetch(url, {
+		const response = await fetchWithRetry(url, {
 			method: 'PUT',
 			headers: {
 				'Content-Type': 'application/json',
@@ -134,7 +229,7 @@ export async function trelloDelete(endpoint: string, credentials: TrelloCredenti
 		}
 
 		const url = createTrelloUrl(endpoint, credentials, params);
-		const response = await fetch(url, {
+		const response = await fetchWithRetry(url, {
 			method: 'DELETE',
 			headers: {
 				'Content-Type': 'application/json',


### PR DESCRIPTION
## Context

We've been using this MCP server in production for a few months with Claude Code + Cursor AI to manage a Trello board where our founder posts review feedback — cards with screenshots, comments with inline images, etc. Along the way we hit several real-world issues and built solutions for them. Sharing back in case it's useful.

## Problems we encountered

### 1. CloudFront TLS blocking
After 5-10 sequential API calls, Trello's CloudFront CDN started refusing new TLS connections from our IP for 10-30 minutes. This made the MCP server essentially unusable during any multi-card workflow (e.g. reading a list of cards, then fetching details for each).

**Fix:** Added a persistent `https.Agent` with `keepAlive: true` that reuses TLS connections instead of opening new ones for every request. This completely solved the blocking issue.

### 2. Tool handlers bypassed retry/keep-alive layer (critical bug)
The resource handlers in `index.ts` used `fetchWithRetry()` with keep-alive and rate limiting, but **all 32 tool handlers** across 5 files (`boards.ts`, `lists.ts`, `cards.ts`, `labels.ts`, `actions.ts`) were still using bare `fetch()`. This meant every tool call was subject to CloudFront TLS drops, with no retry, no rate limiting, and no timeout protection. Resources worked fine while tools failed with `TypeError: fetch failed`.

**Fix:** Replaced all 32 bare `fetch()` calls with `fetchWithRetry()` in all tool handler files. Now every API call goes through the same reliability layer: keep-alive agent, sliding window rate limiter (80 req/10s), exponential backoff with jitter, and 60s timeout.

### 3. Trello API timeouts and flakiness
Trello API regularly takes 20-35 seconds to respond. The default fetch had no timeout, so requests would hang indefinitely. Combined with occasional 429 (rate limit) and 5xx responses, the MCP server was unreliable.

**Fix:** Added `fetchWithRetry()` — a wrapper with:
- AbortController timeout (60s)
- Exponential backoff retry (7 attempts with jitter)
- Sliding window rate limiter (80 req/10s, mutex-protected)
- Retry-After header support for 429 responses
- Retry on network errors and 5xx

### 4. No way to download card attachments
Our founder posts screenshots directly in Trello comments. We needed to download these images to review them locally via AI agents. The Trello file download endpoint returns **401 when using query parameter auth** (`?key=...&token=...`) — it requires an **OAuth Authorization header** instead. This is undocumented behavior.

**Fix:** Added two new tools:
- `get-card-attachments` — lists attachments with metadata and maps them to their parent comments (`commentContext`)
- `download-card-attachments` — downloads files using proper OAuth header, creates numbered files + `_manifest.json`

### 5. Batch operations for AI agent workflows
AI agents (Claude Code, Cursor) often need to create/move/archive multiple cards or add multiple comments in a single logical operation. Making N sequential tool calls is slow and error-prone.

**Fix:** Added batch variants:
- `create-cards` — create multiple cards in one call
- `move-cards` — move multiple cards
- `add-comments` — add comments to multiple cards
- `archive-cards` — archive multiple cards

## Changes

| File | What changed |
|------|-------------|
| `src/utils/api.ts` | Keep-alive HTTPS agent, `fetchWithRetry()` with timeout + backoff + rate limiter |
| `src/tools/boards.ts` | Use `fetchWithRetry` instead of bare `fetch` |
| `src/tools/lists.ts` | Use `fetchWithRetry` instead of bare `fetch` (10 calls) |
| `src/tools/cards.ts` | Use `fetchWithRetry` + 6 new tools (batch ops + attachments) |
| `src/tools/labels.ts` | Use `fetchWithRetry` instead of bare `fetch` (8 calls) |
| `src/tools/actions.ts` | Use `fetchWithRetry` instead of bare `fetch` (4 calls) |
| `src/index.ts` | Use `fetchWithRetry` in resource handlers |

## Notes

- All changes are backwards-compatible — existing tool signatures are unchanged
- The retry layer is shared by both resource handlers and all tool handlers
- Happy to split this into smaller PRs if preferred